### PR TITLE
Proof of Concept: Using Alpine as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM debian:9.6-slim
+FROM alpine:3.9
 
 LABEL "com.github.actions.name"="Assignee to reviewer"
 LABEL "com.github.actions.description"="Automatically create review requests based on assignees"
 LABEL "com.github.actions.icon"="arrow-up-right"
 LABEL "com.github.actions.color"="gray-dark"
 
-LABEL version="1.0.4"
+LABEL version="2.0.0"
 LABEL repository="http://github.com/pullreminders/assignee-to-reviewer-action"
 LABEL homepage="http://github.com/pullreminders/assignee-to-reviewer-action"
 LABEL maintainer="Abi Noda <abi@pullreminders.com>"
 
-RUN apt-get update && apt-get install -y \
-    curl \
-    jq
+RUN apk add --update \
+  curl \
+  jq
 
 ADD entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/ash", "/entrypoint.sh"]


### PR DESCRIPTION
This PR updates the Dockerfile to use `alpine:3.9` as a base image.

See https://hub.docker.com/_/alpine for more details.

### Try it


```workflow
workflow "handle-it" {
  on = "pull_request"
  resolves = ["Assignee to reviewer"]
}

action "Assignee to reviewer" {
  uses = "francisfuzz/assignee-to-reviewer-action-1@5d053f7"
  secrets = ["GITHUB_TOKEN"]
}
```