### PR TITLE
Add the ability to set a REVIEWERS_UNMODIFIED_EXIT_CODE, avoiding parallel action cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ action "Assignee to reviewer" {
   secrets = [
     "GITHUB_TOKEN"
   ]
+
+  # add this line if you want to continue running parrallel github actions even if this action is skipped/not needed
+  env = {
+    REVIEWERS_UNMODIFIED_EXIT_CODE = "0"
+  }
+}
 }
 ```
 


### PR DESCRIPTION
setting a REVIEWERS_UNMODIFIED_EXIT_CODE will allow consumers of this github action to set an exit status (my use case: exit code 0), this can be useful for preventing cancellation of parallel github actions if the assignee-to-reviewer action is skipped/not needed.