### PR TITLE
Update to actions v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,26 @@ If your team currently uses pull request assignees but would like to switch to  
 
 ## Usage
 
-This Action subscribes to [Pull request events](https://developer.github.com/v3/activity/events/types/#pullrequestevent) which fire whenever users are assigned or unassigned to pull requests.
+This Action subscribes to [Pull request events](https://help.github.com/en/articles/events-that-trigger-workflows#pull-request-event-pull_request) specifically the `assigned` and `unassigned` events which fire whenever users are assigned or unassigned to pull requests.
 
 ```workflow
-workflow "Assign reviewers based on assignees" {
-  on = "pull_request"
-  resolves = ["Assignee to reviewer"]
-}
+name: Assign reviewers based on assignees
+on:
+  pull_request:
+    types: [assigned, unassigned]
 
-action "Assignee to reviewer" {
-  uses = "pullreminders/assignee-to-reviewer-action@master"
-  secrets = [
-    "GITHUB_TOKEN"
-  ]
+jobs:
+  assignee_to_reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assignee to Reviewer
+        uses: pullreminders/assignee-to-reviewer-action@v1.0.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # add this line if you want to continue running parallel github actions even if this action is skipped/not needed
-  env = {
-    REVIEWERS_UNMODIFIED_EXIT_CODE = "0"
-  }
-}
 ```
+
+Note that the workflow for `pull_request` events will be triggered by default only for `opened`, `synchronize` or `reopened` activity types. For other, events the `types` keyword must be used.
 
 ## Demo
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
 fi
 
 if [[ -z "$GITHUB_EVENT_NAME" ]]; then
-  echo "Set the GITHUB_REPOSITORY env variable."
+  echo "Set the GITHUB_EVENT_NAME env variable."
   exit 1
 fi
 
@@ -22,12 +22,6 @@ AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")
 number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 assignee=$(jq --raw-output .assignee.login "$GITHUB_EVENT_PATH")
-
-# Github Actions will mark a check as "neutral" (neither failed/succeeded) when you exit with code 78
-# But this will terminate any other Actions running in parallel in the same workflow.
-# Configuring this Environment Variable `REVIEWERS_UNMODIFIED_EXIT_CODE=0` if no reviewer was added or deleted.
-# Docs: https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses
-REVIEWERS_UNMODIFIED_EXIT_CODE=${REVIEWERS_UNMODIFIED_EXIT_CODE:-78}
 
 update_review_request() {
   curl -sSL \
@@ -45,5 +39,5 @@ elif [[ "$action" == "unassigned" ]]; then
   update_review_request 'DELETE'
 else
   echo "Ignoring action ${action}"
-  exit "$REVIEWERS_UNMODIFIED_EXIT_CODE"
+  exit 0
 fi


### PR DESCRIPTION
Hi there.

I came across this GH action and it looks some of the the GH actions features used were deprecated as of actions v2. I have made the following updates:

- Updated the README to the new YAML syntax.
- Added the `types` keyword to the workflow. Pull request workflows are triggered by default only for certain events.
- I removed the use of the neutral exit code since it is also deprecated.

You can see the updated action in action (no pun intended) in lionel1704/gh-actions-demo#4

The workflow is defined [here](https://github.com/lionel1704/gh-actions-demo/blob/master/.github/workflows/assignee_to_reviewer.yml)

resolves #7 
resolves #8 